### PR TITLE
Fixes the following error when compiling with Python 3.9:

### DIFF
--- a/simpleparse/stt/TextTools/mxTextTools/mxTextTools.c
+++ b/simpleparse/stt/TextTools/mxTextTools/mxTextTools.c
@@ -2835,7 +2835,7 @@ PyObject *mxTextTools_UnicodeJoin(PyObject *seq,
 
 	o = PySequence_GetItem(seq, i);
 
-	if PyTuple_Check(o) {
+	if (PyTuple_Check(o)) {
 	    /* Tuple entry: (string,l,r,[...]) */
 	    register Py_ssize_t l,r;
 
@@ -2980,7 +2980,7 @@ PyObject *mxTextTools_Join(PyObject *seq,
 
 	o = PySequence_GetItem(seq, i);
 
-	if PyTuple_Check(o) {
+	if (PyTuple_Check(o)) {
 	    /* Tuple entry: (string,l,r,[...]) */
 	    register Py_ssize_t l,r;
 


### PR DESCRIPTION
note: in expansion of macro ‘PyTuple_Check’
2838 | if PyTuple_Check(o) {
| ^~~~~~~~~~~~~
/builddir/build/BUILD/SimpleParse-2.2.0/simpleparse/stt/TextTools/mxTextTools/mxTextTools.c:2838:22: error: expected ‘;’ before ‘{’ token
2838 | if PyTuple_Check(o) {

https://github.com/mcfletch/simpleparse/issues/10