### PR TITLE
Fix for a missing macro in python 3.11

### DIFF
--- a/simpleparse/stt/TextTools/mxTextTools/mxTextTools.c
+++ b/simpleparse/stt/TextTools/mxTextTools/mxTextTools.c
@@ -2898,13 +2898,13 @@ PyObject *mxTextTools_UnicodeJoin(PyObject *seq,
 
 	/* Insert separator */
 	if (i > 0 && sep_len > 0) {
-	    Py_UNICODE_COPY(p, sep, sep_len);
+	    PyUnicode_CopyCharacters(p, 0, sep, 0, sep_len);
 	    p += sep_len;
 	    current_len += sep_len;
 	}
 
 	/* Copy snippet into new string */
-	Py_UNICODE_COPY(p, st, len_st);
+	PyUnicode_CopyCharacters(p, 0, st, 0, len_st);
 	p += len_st;
 	current_len += len_st;
 	

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py39,py27,py36,py37,py38
+envlist=py27,py36,py37,py38,py39,py310,py311
 skip_missing_interpreters = True
 toxworkdir={toxinidir}/../simpleparse-tox
 


### PR DESCRIPTION
There are still lots of deprecation warning when building, but this fixes compilation errors when trying to build/install in python 3.11:

Fixes for the errors:
`    simpleparse/stt/TextTools/mxTextTools/mxTextTools.c:2901:6: error: implicit declaration of function 'Py_UNICODE_COPY' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                Py_UNICODE_COPY(p, sep, sep_len);
                ^
    simpleparse/stt/TextTools/mxTextTools/mxTextTools.c:2907:2: error: implicit declaration of function 'Py_UNICODE_COPY' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
            Py_UNICODE_COPY(p, st, len_st);
`