### PR TITLE
mxTextTools: Replace Py_UNICODE_COPY with memcpy

### DIFF
--- a/simpleparse/stt/TextTools/mxTextTools/mxTextTools.c
+++ b/simpleparse/stt/TextTools/mxTextTools/mxTextTools.c
@@ -2898,13 +2898,13 @@ PyObject *mxTextTools_UnicodeJoin(PyObject *seq,
 
 	/* Insert separator */
 	if (i > 0 && sep_len > 0) {
-	    Py_UNICODE_COPY(p, sep, sep_len);
+	    memcpy(p, sep, sep_len * sizeof(*p));
 	    p += sep_len;
 	    current_len += sep_len;
 	}
 
 	/* Copy snippet into new string */
-	Py_UNICODE_COPY(p, st, len_st);
+	memcpy(p, st, len_st * sizeof(*p));
 	p += len_st;
 	current_len += len_st;
 	


### PR DESCRIPTION
Current Python 3 no longer supports Py_UNICODE_COPY.

This should fix issue #20.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
